### PR TITLE
Resolve the problem of memory leaks in exception flow

### DIFF
--- a/QCamera2/stack/mm-jpeg-interface/src/mm_jpeg.c
+++ b/QCamera2/stack/mm-jpeg-interface/src/mm_jpeg.c
@@ -2371,6 +2371,7 @@ static int32_t mm_jpeg_read_meta_keyfile(mm_jpeg_job_session_t *p_session,
 
   if (!p_session->meta_enc_key) {
     CDBG_ERROR("%s:%d] error", __func__, __LINE__);
+    fclose(fp);
     return -1;
   }
 


### PR DESCRIPTION
Resolve the memory leaks when doing alloc failed
Test: Compiles and device boots up.